### PR TITLE
Remove redundant __dirname polyfill from build script

### DIFF
--- a/scripts/simple-build.sh
+++ b/scripts/simple-build.sh
@@ -57,7 +57,7 @@ cat > dist/public/index.html << 'EOF'
 </html>
 EOF
 
-# Build server with __dirname polyfill
+# Build server (server/index.ts already defines __dirname polyfill)
 echo "Building server..."
 npx esbuild server/index.ts \
   --platform=node \
@@ -65,9 +65,6 @@ npx esbuild server/index.ts \
   --bundle \
   --format=esm \
   --outdir=dist \
-  --define:__dirname=\"import.meta.dirname\" \
-  --define:__filename=\"import.meta.filename\" \
-  --banner:js="import { fileURLToPath } from 'url'; import { dirname } from 'path'; const __filename = fileURLToPath(import.meta.url); const __dirname = dirname(__filename);" \
   2>&1
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary
- remove duplicate `__dirname` polyfill injection in `scripts/simple-build.sh`
- rely on existing polyfill in `server/index.ts` to avoid runtime redeclaration errors

## Testing
- `npm test` *(fails: Database error)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c086dbf120832795f4fd81419ee7cb