### PR TITLE
Fix dev server template loading and alias handling

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@shared": path.resolve(__dirname, "../shared"),
     },
   },
   server: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,31 +1,34 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  root: path.resolve(__dirname, './client'),
+  root: path.resolve(rootDir, "./client"),
   plugins: [react()],
   build: {
-    outDir: path.resolve(__dirname, './dist/public'),
+    outDir: path.resolve(rootDir, "./dist/public"),
     emptyOutDir: true,
     sourcemap: false,
     minify: false, // Disable minification to reduce memory usage
     chunkSizeWarningLimit: 5000,
     rollupOptions: {
       input: {
-        main: path.resolve(__dirname, './client/index.html')
+        main: path.resolve(rootDir, "./client/index.html"),
       },
       output: {
         // Disable code splitting to reduce memory usage
         manualChunks: undefined,
-        inlineDynamicImports: true
-      }
-    }
+        inlineDynamicImports: true,
+      },
+    },
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./client/src"),
-      "@shared": path.resolve(__dirname, "./shared"),
-    }
-  }
+      "@": path.resolve(rootDir, "./client/src"),
+      "@shared": path.resolve(rootDir, "./shared"),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- load the client index template safely in the dev middleware and reuse the project Vite config so requests return HTML again
- add the shared module alias to the client Vite config so front-end imports resolve during builds
- make the root Vite config ESM-safe by deriving paths from import.meta.url

## Testing
- npm run build
- npm run check *(fails: existing TypeScript parse errors in Compass.tsx and perfectDashboardExport.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7315de248327bdd5d3d2c59105c1